### PR TITLE
Fix default CLI behaviour and adjust colours

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2,6 +2,11 @@ import typer
 from typing import Optional
 
 from scraper import JobScraper
+import typer.rich_utils as rich_utils
+rich_utils.STYLE_COMMANDS_TABLE_FIRST_COLUMN="bold sky_blue3"
+rich_utils.STYLE_OPTION="bold sky_blue3"
+rich_utils.STYLE_USAGE="yellow3"
+rich_utils.STYLE_METAVAR="bold yellow3"
 
 app = typer.Typer(help="Command line interface for JobScraper")
 
@@ -20,6 +25,10 @@ def main(ctx: typer.Context,
     ctx.obj["no_auto_clean"] = no_auto_clean
     ctx.call_on_close(scraper.close)
     if ctx.invoked_subcommand is None:
+        import sys
+        if len(sys.argv) == 1:
+            typer.echo(ctx.get_help())
+            raise typer.Exit()
         scraper.run()
 
 @app.command()


### PR DESCRIPTION
## Summary
- show help when running scraper.py without options
- tweak CLI blue and yellow styles

## Testing
- `python -m py_compile cli.py scraper.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68570f97c71483329dbcf5cf90cddd3f