### PR TITLE
Refactor CLI naming and adjust guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,13 +14,9 @@ General guidelines for maintaining the **JobScraps** repository.
 ## Coding Conventions
 
 - Follow PEP 8 formatting (use 4-space indentation).
-    
+
 - Add type hints to public functions and classes.
-    
-- Prefer `logging` over `print` for output.
-    
 - Keep functions small and readable.
-    
 
 ## Git and PR Workflow
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,7 +2,7 @@
 
 Utility scripts for JobScraps data management:
 
-- **cli.py**: Command-line interface utilities
+- **db_stats_cli.py**: Database statistics CLI (legacy)
 - **csv_to_config.py**: Convert CSV data to configuration files
 - **log_parser.py**: Parse and analyze application logs
   (uses `configs/log_parser_config.json` for defaults)

--- a/scripts/db_stats_cli.py
+++ b/scripts/db_stats_cli.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# cli.py - Command-line interface for JobSpy
+# db_stats_cli.py - Legacy database interface for JobSpy
 
 import typer
 import sqlite3


### PR DESCRIPTION
## Summary
- rename `scripts/cli.py` to `db_stats_cli.py`
- update scripts README to point to the renamed script
- remove the logging preference from `AGENTS.md`
- tweak script header comment

## Testing
- `python dev/verify_setup.py` *(fails: Error loading config)*

------
https://chatgpt.com/codex/tasks/task_e_685ab2e1139483328cbde34817e0a2ab