### PR TITLE
Add pyproject and export Typer app

### DIFF
--- a/jobscraps/cli.py
+++ b/jobscraps/cli.py
@@ -8,7 +8,7 @@ rich_utils.STYLE_OPTION="bold sky_blue3"
 rich_utils.STYLE_USAGE="yellow3"
 rich_utils.STYLE_METAVAR="bold yellow3"
 
-app = typer.Typer(help="Command line interface for JobScraper")
+app: typer.Typer = typer.Typer(help="Command line interface for JobScraper")
 
 @app.callback(invoke_without_command=True)
 def main(ctx: typer.Context,
@@ -110,6 +110,8 @@ def test_backup(ctx: typer.Context, filename: str = typer.Argument(..., help="Ba
 def cleanup_backups(ctx: typer.Context):
     """Force cleanup of old backups."""
     ctx.obj["scraper"].cleanup_backups()
+
+__all__ = ["app"]
 
 if __name__ == "__main__":
     app()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=67"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "jobscraps"
+version = "0.1.0"
+readme = "README.md"
+description = "JobScraps job scraping and data management system"
+requires-python = ">=3.10"
+
+[project.scripts]
+jobscraps = "jobscraps.cli:app"


### PR DESCRIPTION
## Summary
- create minimal `pyproject.toml` with script entry
- expose `app` variable from `cli.py`

## Testing
- `python dev/verify_setup.py` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_685b49fb2a148332b788a2a0b25cacf8