### PR TITLE
Add search history session migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,20 @@ This project is actively maintained. Major components include:
 - `data_cleaner.py` and `duplicate_manager.py` - Data quality utilities
 - `database/` - Connection and backup helpers
 
+## 🛠 Database Migration
+
+A migration script `sql/migrate_search_history_sessions.sql` upgrades the
+`search_history` table with session tracking fields. Execute the statements in
+that file to:
+
+1. Add new columns with defaults.
+2. Backfill `session_id` and `session_sequence` using `ROW_NUMBER`.
+3. Enforce `NOT NULL` constraints and create indexes, including GIN indexes on
+   the JSONB breakdown columns.
+
+Run the commands in order against your PostgreSQL database to update existing
+installations.
+
 ## 📄 License
 
 MIT License - see LICENSE file for details.

--- a/sql/migrate_search_history_sessions.sql
+++ b/sql/migrate_search_history_sessions.sql
@@ -1,0 +1,35 @@
+-- Migration: add session tracking columns to search_history
+
+-- 1. Add new columns with defaults
+ALTER TABLE search_history
+    ADD COLUMN IF NOT EXISTS session_id TEXT,
+    ADD COLUMN IF NOT EXISTS session_sequence INTEGER DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS duration INTEGER DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS new_jobs_inserted INTEGER DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS site_breakdown JSONB DEFAULT '{}'::jsonb,
+    ADD COLUMN IF NOT EXISTS duplicate_breakdown JSONB DEFAULT '{}'::jsonb;
+
+-- 2. Backfill existing rows using row_number ordering by timestamp
+WITH ordered AS (
+    SELECT id, ROW_NUMBER() OVER (ORDER BY timestamp) AS rn
+    FROM search_history
+)
+UPDATE search_history sh
+SET session_sequence = o.rn,
+    session_id = md5(sh.timestamp::text || '-' || o.rn::text)
+FROM ordered o
+WHERE sh.id = o.id;
+
+-- 3. Enforce not-null constraints after backfill
+ALTER TABLE search_history
+    ALTER COLUMN session_id SET NOT NULL,
+    ALTER COLUMN session_sequence SET NOT NULL,
+    ALTER COLUMN new_jobs_inserted SET NOT NULL;
+
+-- 4. Create indexes for improved query performance
+CREATE INDEX IF NOT EXISTS idx_search_history_session_id ON search_history(session_id);
+CREATE INDEX IF NOT EXISTS idx_search_history_date_session ON search_history(timestamp, session_sequence);
+CREATE INDEX IF NOT EXISTS idx_search_history_duration ON search_history(duration);
+CREATE INDEX IF NOT EXISTS idx_search_history_new_jobs ON search_history(new_jobs_inserted);
+CREATE INDEX IF NOT EXISTS idx_search_history_site_breakdown ON search_history USING GIN (site_breakdown);
+CREATE INDEX IF NOT EXISTS idx_search_history_duplicate_breakdown ON search_history USING GIN (duplicate_breakdown);


### PR DESCRIPTION
## Summary
- add `migrate_search_history_sessions.sql` migration
- document database migration steps in README

## Testing
- `python dev/verify_setup.py` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_685c1c17a3f88332b7a5e10679b245e4