### PR TITLE
Add session metrics to search history

### DIFF
--- a/data/schemas/README.md
+++ b/data/schemas/README.md
@@ -17,3 +17,10 @@ pg_dump -h HOST -p 5432 -U USER -d jobscraps \
 ## Key Tables
 - **scraped_jobs**: Main table storing all job records
 - **search_history**: Tracks scraping operations
+
+## Schema Upgrades
+Migration scripts are stored in `data/schemas/migrations`. Apply them with psql:
+
+```bash
+psql -h HOST -U USER -d jobscraps -f data/schemas/migrations/001_add_search_metrics.sql
+```

--- a/data/schemas/jobscraps_schema.sql
+++ b/data/schemas/jobscraps_schema.sql
@@ -158,6 +158,13 @@ CREATE TABLE public.search_history (
     id integer NOT NULL,
     search_query text,
     parameters text,
+    session_id text,
+    new_jobs_inserted integer,
+    duration_seconds numeric,
+    site_breakdown text,
+    duplicate_breakdown text,
+    remote_jobs_count integer,
+    avg_salary numeric(12,2),
     "timestamp" timestamp without time zone,
     jobs_found integer
 );

--- a/data/schemas/migrations/001_add_search_metrics.sql
+++ b/data/schemas/migrations/001_add_search_metrics.sql
@@ -1,0 +1,8 @@
+-- Migration: add columns for extended search metrics
+ALTER TABLE search_history ADD COLUMN IF NOT EXISTS session_id TEXT;
+ALTER TABLE search_history ADD COLUMN IF NOT EXISTS new_jobs_inserted INTEGER;
+ALTER TABLE search_history ADD COLUMN IF NOT EXISTS duration_seconds NUMERIC;
+ALTER TABLE search_history ADD COLUMN IF NOT EXISTS site_breakdown TEXT;
+ALTER TABLE search_history ADD COLUMN IF NOT EXISTS duplicate_breakdown TEXT;
+ALTER TABLE search_history ADD COLUMN IF NOT EXISTS remote_jobs_count INTEGER;
+ALTER TABLE search_history ADD COLUMN IF NOT EXISTS avg_salary NUMERIC(12,2);

--- a/jobscraps/database/backup.py
+++ b/jobscraps/database/backup.py
@@ -342,15 +342,23 @@ class BackupMixin:
             search_backup_path = os.path.join(backup_dir, f"search_history_{timestamp}.csv")
             search_df.to_csv(search_backup_path, index=False)
             logger.info("Search history CSV backup created at %s", search_backup_path)
+
+            session_df = pd.read_sql("SELECT * FROM search_sessions", self.conn)
+            session_backup_path = os.path.join(backup_dir, f"search_sessions_{timestamp}.csv")
+            session_df.to_csv(session_backup_path, index=False)
+            logger.info("Search sessions CSV backup created at %s", session_backup_path)
             rows_deleted = self.clear_all_jobs()
             with self.conn.cursor() as cursor:
                 cursor.execute("DELETE FROM search_history")
                 search_rows_deleted = cursor.rowcount
+                cursor.execute("DELETE FROM search_sessions")
+                session_rows_deleted = cursor.rowcount
                 self.conn.commit()
             logger.info(
-                "Database reset completed. Jobs: %s, Search history: %s",
+                "Database reset completed. Jobs: %s, Search history: %s, Sessions: %s",
                 rows_deleted,
                 search_rows_deleted,
+                session_rows_deleted,
             )
             return True
         except Exception as e:  # pylint: disable=broad-except

--- a/jobscraps/database/core.py
+++ b/jobscraps/database/core.py
@@ -105,8 +105,17 @@ class JobDatabase(BackupMixin):
             )
             cursor.execute(
                 """
+            CREATE TABLE IF NOT EXISTS search_sessions (
+                id SERIAL PRIMARY KEY,
+                start_time TIMESTAMP
+            )
+            """
+            )
+            cursor.execute(
+                """
             CREATE TABLE IF NOT EXISTS search_history (
                 id SERIAL PRIMARY KEY,
+                session_id INTEGER REFERENCES search_sessions(id),
                 search_query TEXT,
                 parameters TEXT,
                 session_id TEXT,
@@ -137,6 +146,7 @@ class JobDatabase(BackupMixin):
                 "CREATE INDEX IF NOT EXISTS idx_scraped_jobs_description_gin ON scraped_jobs USING gin (description gin_trgm_ops)",
                 "CREATE INDEX IF NOT EXISTS idx_search_history_search_query ON search_history(search_query)",
                 "CREATE INDEX IF NOT EXISTS idx_search_history_timestamp ON search_history(timestamp)",
+                "CREATE INDEX IF NOT EXISTS idx_search_history_session_id ON search_history(session_id)",
             ]
             for query in index_queries:
                 try:
@@ -224,12 +234,23 @@ class JobDatabase(BackupMixin):
             logger.info("No new jobs to insert")
         return new_jobs_count
 
-    def log_search(self, search_query: str, parameters: Dict, jobs_found: int) -> None:
+    def start_session(self) -> int:
         self._ensure_connection()
         with self.conn.cursor() as cursor:
             cursor.execute(
-                "INSERT INTO search_history (search_query, parameters, timestamp, jobs_found) VALUES (%s, %s, %s, %s)",
-                (search_query, json.dumps(parameters), datetime.now(), jobs_found),
+                "INSERT INTO search_sessions (start_time) VALUES (%s) RETURNING id",
+                (datetime.now(),),
+            )
+            session_id = cursor.fetchone()[0]
+            self.conn.commit()
+        return session_id
+
+    def log_search(self, session_id: int, search_query: str, parameters: Dict, jobs_found: int) -> None:
+        self._ensure_connection()
+        with self.conn.cursor() as cursor:
+            cursor.execute(
+                "INSERT INTO search_history (session_id, search_query, parameters, timestamp, jobs_found) VALUES (%s, %s, %s, %s, %s)",
+                (session_id, search_query, json.dumps(parameters), datetime.now(), jobs_found),
             )
             self.conn.commit()
 

--- a/jobscraps/database/core.py
+++ b/jobscraps/database/core.py
@@ -109,6 +109,13 @@ class JobDatabase(BackupMixin):
                 id SERIAL PRIMARY KEY,
                 search_query TEXT,
                 parameters TEXT,
+                session_id TEXT,
+                new_jobs_inserted INTEGER,
+                duration_seconds NUMERIC,
+                site_breakdown TEXT,
+                duplicate_breakdown TEXT,
+                remote_jobs_count INTEGER,
+                avg_salary NUMERIC(12,2),
                 timestamp TIMESTAMP,
                 jobs_found INTEGER
             )

--- a/jobscraps/scraper.py
+++ b/jobscraps/scraper.py
@@ -84,6 +84,9 @@ class JobScraper:
         self.config = JobSearchConfig(config_path)
         self.db = JobDatabase(db_config_path, database_type)
         self.duplicate_manager = DuplicateManager(self.db)
+
+        self.session_id = self.db.start_session()
+        logger.info("Started search session %s", self.session_id)
         
         self.proxies = [
         ]
@@ -121,7 +124,7 @@ class JobScraper:
                 jobs_df = scrape_jobs(**params)
                 
                 # Log the search
-                self.db.log_search(job_name, params, len(jobs_df))
+                self.db.log_search(self.session_id, job_name, params, len(jobs_df))
                 
                 # Insert results into database
                 new_jobs = self.db.insert_jobs(jobs_df, job_name)


### PR DESCRIPTION
## Summary
- track more session metrics in `search_history`
- update schema dump
- add migration SQL and document upgrade steps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e8a498f088332a2e41862f040729a