### PR TITLE
Add search session tracking

### DIFF
--- a/jobscraps/database/backup.py
+++ b/jobscraps/database/backup.py
@@ -342,15 +342,23 @@ class BackupMixin:
             search_backup_path = os.path.join(backup_dir, f"search_history_{timestamp}.csv")
             search_df.to_csv(search_backup_path, index=False)
             logger.info("Search history CSV backup created at %s", search_backup_path)
+
+            session_df = pd.read_sql("SELECT * FROM search_sessions", self.conn)
+            session_backup_path = os.path.join(backup_dir, f"search_sessions_{timestamp}.csv")
+            session_df.to_csv(session_backup_path, index=False)
+            logger.info("Search sessions CSV backup created at %s", session_backup_path)
             rows_deleted = self.clear_all_jobs()
             with self.conn.cursor() as cursor:
                 cursor.execute("DELETE FROM search_history")
                 search_rows_deleted = cursor.rowcount
+                cursor.execute("DELETE FROM search_sessions")
+                session_rows_deleted = cursor.rowcount
                 self.conn.commit()
             logger.info(
-                "Database reset completed. Jobs: %s, Search history: %s",
+                "Database reset completed. Jobs: %s, Search history: %s, Sessions: %s",
                 rows_deleted,
                 search_rows_deleted,
+                session_rows_deleted,
             )
             return True
         except Exception as e:  # pylint: disable=broad-except

--- a/jobscraps/database/core.py
+++ b/jobscraps/database/core.py
@@ -105,8 +105,17 @@ class JobDatabase(BackupMixin):
             )
             cursor.execute(
                 """
+            CREATE TABLE IF NOT EXISTS search_sessions (
+                id SERIAL PRIMARY KEY,
+                start_time TIMESTAMP
+            )
+            """
+            )
+            cursor.execute(
+                """
             CREATE TABLE IF NOT EXISTS search_history (
                 id SERIAL PRIMARY KEY,
+                session_id INTEGER REFERENCES search_sessions(id),
                 search_query TEXT,
                 parameters TEXT,
                 timestamp TIMESTAMP,
@@ -130,6 +139,7 @@ class JobDatabase(BackupMixin):
                 "CREATE INDEX IF NOT EXISTS idx_scraped_jobs_description_gin ON scraped_jobs USING gin (description gin_trgm_ops)",
                 "CREATE INDEX IF NOT EXISTS idx_search_history_search_query ON search_history(search_query)",
                 "CREATE INDEX IF NOT EXISTS idx_search_history_timestamp ON search_history(timestamp)",
+                "CREATE INDEX IF NOT EXISTS idx_search_history_session_id ON search_history(session_id)",
             ]
             for query in index_queries:
                 try:
@@ -217,12 +227,23 @@ class JobDatabase(BackupMixin):
             logger.info("No new jobs to insert")
         return new_jobs_count
 
-    def log_search(self, search_query: str, parameters: Dict, jobs_found: int) -> None:
+    def start_session(self) -> int:
         self._ensure_connection()
         with self.conn.cursor() as cursor:
             cursor.execute(
-                "INSERT INTO search_history (search_query, parameters, timestamp, jobs_found) VALUES (%s, %s, %s, %s)",
-                (search_query, json.dumps(parameters), datetime.now(), jobs_found),
+                "INSERT INTO search_sessions (start_time) VALUES (%s) RETURNING id",
+                (datetime.now(),),
+            )
+            session_id = cursor.fetchone()[0]
+            self.conn.commit()
+        return session_id
+
+    def log_search(self, session_id: int, search_query: str, parameters: Dict, jobs_found: int) -> None:
+        self._ensure_connection()
+        with self.conn.cursor() as cursor:
+            cursor.execute(
+                "INSERT INTO search_history (session_id, search_query, parameters, timestamp, jobs_found) VALUES (%s, %s, %s, %s, %s)",
+                (session_id, search_query, json.dumps(parameters), datetime.now(), jobs_found),
             )
             self.conn.commit()
 

--- a/jobscraps/scraper.py
+++ b/jobscraps/scraper.py
@@ -84,6 +84,9 @@ class JobScraper:
         self.config = JobSearchConfig(config_path)
         self.db = JobDatabase(db_config_path, database_type)
         self.duplicate_manager = DuplicateManager(self.db)
+
+        self.session_id = self.db.start_session()
+        logger.info("Started search session %s", self.session_id)
         
         self.proxies = [
         ]
@@ -121,7 +124,7 @@ class JobScraper:
                 jobs_df = scrape_jobs(**params)
                 
                 # Log the search
-                self.db.log_search(job_name, params, len(jobs_df))
+                self.db.log_search(self.session_id, job_name, params, len(jobs_df))
                 
                 # Insert results into database
                 new_jobs = self.db.insert_jobs(jobs_df, job_name)


### PR DESCRIPTION
## Summary
- track scraping sessions in the database
- start a new session whenever the scraper is initialised via the CLI
- associate search logs with their session
- backup and clean session data during reset

## Testing
- `pytest -q`
- `python -m py_compile jobscraps/database/core.py jobscraps/scraper.py jobscraps/database/backup.py`


------
https://chatgpt.com/codex/tasks/task_e_685effad5ab48332a2729d707c41ad5c