### PR TITLE
Fix search_history schema

### DIFF
--- a/data/schemas/jobscraps_schema.sql
+++ b/data/schemas/jobscraps_schema.sql
@@ -19,6 +19,7 @@ SET row_security = off;
 
 DROP INDEX IF EXISTS public.idx_search_history_timestamp;
 DROP INDEX IF EXISTS public.idx_search_history_search_query;
+DROP INDEX IF EXISTS public.idx_search_history_session_id;
 DROP INDEX IF EXISTS public.idx_scraped_jobs_title_company;
 DROP INDEX IF EXISTS public.idx_scraped_jobs_title;
 DROP INDEX IF EXISTS public.idx_scraped_jobs_site;
@@ -36,6 +37,8 @@ ALTER TABLE IF EXISTS ONLY public.scraped_jobs DROP CONSTRAINT IF EXISTS scraped
 ALTER TABLE IF EXISTS public.search_history ALTER COLUMN id DROP DEFAULT;
 DROP SEQUENCE IF EXISTS public.search_history_id_seq;
 DROP TABLE IF EXISTS public.search_history;
+DROP SEQUENCE IF EXISTS public.search_sessions_id_seq;
+DROP TABLE IF EXISTS public.search_sessions;
 DROP TABLE IF EXISTS public.scraped_jobs;
 DROP EXTENSION IF EXISTS pg_trgm;
 -- *not* dropping schema, since initdb creates it
@@ -149,6 +152,53 @@ COMMENT ON COLUMN public.scraped_jobs.date_scraped IS 'Timestamp when this job w
 
 COMMENT ON COLUMN public.scraped_jobs.search_query IS 'Search query that found this job';
 
+--
+-- Name: search_sessions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.search_sessions (
+    id integer NOT NULL,
+    start_time timestamp without time zone
+);
+
+--
+-- Name: search_sessions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.search_sessions_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+--
+-- Name: search_sessions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.search_sessions_id_seq OWNED BY public.search_sessions.id;
+
+--
+-- Name: search_sessions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.search_sessions ALTER COLUMN id SET DEFAULT nextval('public.search_sessions_id_seq'::regclass);
+
+--
+-- Name: TABLE search_sessions; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.search_sessions IS 'Tracking scraping sessions';
+
+--
+-- Name: search_sessions search_sessions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.search_sessions
+    ADD CONSTRAINT search_sessions_pkey PRIMARY KEY (id);
+
+
 
 --
 -- Name: search_history; Type: TABLE; Schema: public; Owner: -
@@ -158,7 +208,7 @@ CREATE TABLE public.search_history (
     id integer NOT NULL,
     search_query text,
     parameters text,
-    session_id text,
+    session_id integer,
     new_jobs_inserted integer,
     duration_seconds numeric,
     site_breakdown text,
@@ -302,6 +352,13 @@ CREATE INDEX idx_scraped_jobs_title ON public.scraped_jobs USING btree (title);
 --
 
 CREATE INDEX idx_scraped_jobs_title_company ON public.scraped_jobs USING btree (title, company);
+
+--
+-- Name: idx_search_history_session_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_search_history_session_id ON public.search_history USING btree (session_id);
+
 
 
 --

--- a/data/schemas/migrations/001_add_search_metrics.sql
+++ b/data/schemas/migrations/001_add_search_metrics.sql
@@ -1,5 +1,10 @@
 -- Migration: add columns for extended search metrics
-ALTER TABLE search_history ADD COLUMN IF NOT EXISTS session_id TEXT;
+CREATE TABLE IF NOT EXISTS search_sessions (
+    id SERIAL PRIMARY KEY,
+    start_time TIMESTAMP
+);
+ALTER TABLE search_history DROP COLUMN IF EXISTS session_id;
+ALTER TABLE search_history ADD COLUMN IF NOT EXISTS session_id INTEGER REFERENCES search_sessions(id);
 ALTER TABLE search_history ADD COLUMN IF NOT EXISTS new_jobs_inserted INTEGER;
 ALTER TABLE search_history ADD COLUMN IF NOT EXISTS duration_seconds NUMERIC;
 ALTER TABLE search_history ADD COLUMN IF NOT EXISTS site_breakdown TEXT;

--- a/jobscraps/database/core.py
+++ b/jobscraps/database/core.py
@@ -118,7 +118,6 @@ class JobDatabase(BackupMixin):
                 session_id INTEGER REFERENCES search_sessions(id),
                 search_query TEXT,
                 parameters TEXT,
-                session_id TEXT,
                 new_jobs_inserted INTEGER,
                 duration_seconds NUMERIC,
                 site_breakdown TEXT,


### PR DESCRIPTION
## Summary
- drop duplicate `session_id` column when creating `search_history`
- keep search sessions in migrations
- update database schema dump

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f1e8135d48332b8a37f28cff0f83f