### PR TITLE
Add JSONB index support

### DIFF
--- a/data/schemas/jobscraps_schema.sql
+++ b/data/schemas/jobscraps_schema.sql
@@ -20,6 +20,8 @@ SET row_security = off;
 DROP INDEX IF EXISTS public.idx_search_history_timestamp;
 DROP INDEX IF EXISTS public.idx_search_history_search_query;
 DROP INDEX IF EXISTS public.idx_search_history_session_id;
+DROP INDEX IF EXISTS public.idx_search_history_site_breakdown;
+DROP INDEX IF EXISTS public.idx_search_history_duplicate_breakdown;
 DROP INDEX IF EXISTS public.idx_scraped_jobs_title_company;
 DROP INDEX IF EXISTS public.idx_scraped_jobs_title;
 DROP INDEX IF EXISTS public.idx_scraped_jobs_site;
@@ -358,6 +360,20 @@ CREATE INDEX idx_scraped_jobs_title_company ON public.scraped_jobs USING btree (
 --
 
 CREATE INDEX idx_search_history_session_id ON public.search_history USING btree (session_id);
+
+
+--
+-- Name: idx_search_history_site_breakdown; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_search_history_site_breakdown ON public.search_history USING gin (site_breakdown);
+
+
+--
+-- Name: idx_search_history_duplicate_breakdown; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_search_history_duplicate_breakdown ON public.search_history USING gin (duplicate_breakdown);
 
 
 

--- a/jobscraps/database/core.py
+++ b/jobscraps/database/core.py
@@ -146,6 +146,8 @@ class JobDatabase(BackupMixin):
                 "CREATE INDEX IF NOT EXISTS idx_search_history_search_query ON search_history(search_query)",
                 "CREATE INDEX IF NOT EXISTS idx_search_history_timestamp ON search_history(timestamp)",
                 "CREATE INDEX IF NOT EXISTS idx_search_history_session_id ON search_history(session_id)",
+                "CREATE INDEX IF NOT EXISTS idx_search_history_site_breakdown ON search_history USING gin (site_breakdown)",
+                "CREATE INDEX IF NOT EXISTS idx_search_history_duplicate_breakdown ON search_history USING gin (duplicate_breakdown)",
             ]
             for query in index_queries:
                 try:


### PR DESCRIPTION
## Summary
- add gin indexes for new JSONB fields `site_breakdown` and `duplicate_breakdown`
- include matching index definitions in schema dump

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f23226b708332b4115c8fd6a0d19f