### PR TITLE
Add shared DB connection pool

### DIFF
--- a/jobscraps/cli.py
+++ b/jobscraps/cli.py
@@ -2,8 +2,8 @@ import typer
 from typing import Optional
 
 from .scraping_orchestrator import ScrapingOrchestrator
-from .database.core import JobDatabase  # Add this import
-from .console_interface import console  # Add this import
+from .database.core import get_connection
+from .console_interface import console
 
 import typer.rich_utils as rich_utils
 rich_utils.STYLE_COMMANDS_TABLE_FIRST_COLUMN="bold sky_blue3"
@@ -111,7 +111,8 @@ def restore_backup(
     
     db = None
     try:
-        db = JobDatabase(database_type="production")
+        orch_db = ctx.obj["orch"].scraper.db
+        db = get_connection(orch_db.db_config.config_path, orch_db.database_type)
         
         # Test compatibility first
         console.print(f"Testing backup compatibility: {filename}")
@@ -156,9 +157,6 @@ def restore_backup(
     except Exception as e:
         console.print(f"❌ Restore error: {e}")
         raise typer.Exit(1)
-    finally:
-        if db:
-            db.close()
 
 
 @app.command("test-backup")
@@ -180,8 +178,8 @@ def test_backup_compatibility(
     
     db = None
     try:
-        # Use JobDatabase directly instead of orchestrator's scraper
-        db = JobDatabase(database_type="production")
+        orch_db = ctx.obj["orch"].scraper.db
+        db = get_connection(orch_db.db_config.config_path, orch_db.database_type)
         
         console.print(f"Testing backup compatibility: {filename}")
         compat_check = db.test_backup_compatibility(filename)
@@ -205,9 +203,6 @@ def test_backup_compatibility(
     except Exception as e:
         console.print(f"❌ Compatibility test error: {e}")
         raise typer.Exit(1)
-    finally:
-        if db:
-            db.close()
 
 __all__ = ["app"]
 

--- a/jobscraps/database/__init__.py
+++ b/jobscraps/database/__init__.py
@@ -1,5 +1,5 @@
 from .config import DatabaseConfig
-from .core import JobDatabase
+from .core import JobDatabase, get_connection
 from .backup import BackupMixin
 
-__all__ = ["DatabaseConfig", "JobDatabase", "BackupMixin"]
+__all__ = ["DatabaseConfig", "JobDatabase", "BackupMixin", "get_connection"]

--- a/jobscraps/database/core.py
+++ b/jobscraps/database/core.py
@@ -3,7 +3,7 @@ import json
 import time
 import logging
 from datetime import datetime
-from typing import Dict, List
+from typing import Dict, List, Tuple, Optional
 from collections import defaultdict
 
 import pandas as pd
@@ -456,4 +456,29 @@ class JobDatabase(BackupMixin):
         if self.conn and not self.conn.closed:
             self.conn.close()
             logger.info("Database connection closed")
+
+
+class ConnectionPool:
+    """Manage shared JobDatabase instances."""
+
+    _instances: Dict[Tuple[str, str], JobDatabase] = {}
+
+    @classmethod
+    def get_connection(
+        cls, config_path: Optional[str] = None, database_type: str = "production"
+    ) -> JobDatabase:
+        """Return a pooled JobDatabase instance."""
+        key = (config_path or "", database_type)
+        db = cls._instances.get(key)
+        if db is None or db.conn is None or getattr(db.conn, "closed", True):
+            db = JobDatabase(config_path, database_type)
+            cls._instances[key] = db
+        return db
+
+
+def get_connection(
+    config_path: Optional[str] = None, database_type: str = "production"
+) -> JobDatabase:
+    """Convenience wrapper for ConnectionPool.get_connection."""
+    return ConnectionPool.get_connection(config_path, database_type)
 

--- a/jobscraps/scraper.py
+++ b/jobscraps/scraper.py
@@ -28,7 +28,7 @@ from jobspy import scrape_jobs
 from .duplicate_manager import DuplicateManager
 from .config import JobSearchConfig
 
-from .database import DatabaseConfig, JobDatabase
+from .database import get_connection
 from .console_interface import console
 from .backup_manager import BackupManager
 from .data_cleaner import DataCleaner
@@ -82,7 +82,7 @@ class JobScraper:
         if db_config_path is None:
             db_config_path = os.path.join(SCRIPT_DIR, "configs", "db", "db_config.json")
         self.config = JobSearchConfig(config_path)
-        self.db = JobDatabase(db_config_path, database_type)
+        self.db = get_connection(db_config_path, database_type)
         self.duplicate_manager = DuplicateManager(self.db)
 
         self.session_id = self.db.start_session()


### PR DESCRIPTION
## Summary
- create `ConnectionPool` with `get_connection()` helper
- share connections in `JobScraper` and CLI
- expose `get_connection` in `jobscraps.database`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f5b0f9e80833293673d5d56ec7212