### PR TITLE
Add session completion tracking

### DIFF
--- a/jobscraps/__init__.py
+++ b/jobscraps/__init__.py
@@ -8,6 +8,7 @@ from .scraping_orchestrator import ScrapingOrchestrator
 from .console_interface import console
 from .database import DatabaseConfig, JobDatabase, BackupMixin
 from .config import JobSearchConfig
+from .session_manager import SessionManager
 
 __all__ = [
     "JobScraper",
@@ -20,4 +21,5 @@ __all__ = [
     "JobDatabase",
     "BackupMixin",
     "JobSearchConfig",
+    "SessionManager",
 ]

--- a/jobscraps/database/core.py
+++ b/jobscraps/database/core.py
@@ -107,9 +107,17 @@ class JobDatabase(BackupMixin):
                 """
             CREATE TABLE IF NOT EXISTS search_sessions (
                 id SERIAL PRIMARY KEY,
-                start_time TIMESTAMP
+                start_time TIMESTAMP,
+                end_time TIMESTAMP,
+                status TEXT
             )
             """
+            )
+            cursor.execute(
+                "ALTER TABLE search_sessions ADD COLUMN IF NOT EXISTS end_time TIMESTAMP"
+            )
+            cursor.execute(
+                "ALTER TABLE search_sessions ADD COLUMN IF NOT EXISTS status TEXT"
             )
             cursor.execute(
                 """
@@ -277,6 +285,20 @@ class JobDatabase(BackupMixin):
             session_id = cursor.fetchone()[0]
             self.conn.commit()
         return session_id
+
+    def end_session(self, session_id: int, status: str) -> None:
+        """Mark a search session as completed."""
+        self._ensure_connection()
+        with self.conn.cursor() as cursor:
+            cursor.execute(
+                """
+                UPDATE search_sessions
+                SET end_time = %s, status = %s
+                WHERE id = %s
+                """,
+                (datetime.now(), status, session_id),
+            )
+            self.conn.commit()
 
     def log_search(
         self,

--- a/jobscraps/scraper.py
+++ b/jobscraps/scraper.py
@@ -32,6 +32,7 @@ from .database import get_connection
 from .console_interface import console
 from .backup_manager import BackupManager
 from .data_cleaner import DataCleaner
+from .session_manager import SessionManager
 import warnings
 # Suppress pandas SQLAlchemy warnings for psycopg2 connections
 warnings.filterwarnings('ignore', message='pandas only supports SQLAlchemy connectable')
@@ -97,85 +98,93 @@ class JobScraper:
         global_params = self.config.get_global_params()
         job_configs = self.config.get_job_configs()
         
+    
         if not job_configs:
             logger.warning("No enabled job configurations found")
+            self.db.end_session(self.session_id, "no_jobs")
             return
-        
+
         total_new_jobs = 0
-        
-        for job_config in job_configs:
-            job_name = job_config.get("name", "Unnamed Job")
-            params = job_config.get("parameters", {})
-            
-            # Merge with global parameters
-            for key, value in global_params.items():
-                if key not in params:
-                    params[key] = value
-                    
-            # Add proxies if available
-            if self.proxies:
-                params["proxies"] = self.proxies
-                
-            logger.info(f"Starting search for: {job_name}")
-            logger.info(f"Parameters: {params}")
-            
-            try:
-                start_time = time.time()
-                jobs_df = scrape_jobs(**params)
 
-                (
-                    new_jobs,
-                    site_counts,
-                    duplicate_counts,
-                    remote_count,
-                    avg_salary,
-                ) = self.db.insert_jobs(jobs_df, job_name)
+        with SessionManager(self.db, self.session_id):
+            for job_config in job_configs:
+                job_name = job_config.get("name", "Unnamed Job")
+                params = job_config.get("parameters", {})
 
-                duration = time.time() - start_time
+                # Merge with global parameters
+                for key, value in global_params.items():
+                    if key not in params:
+                        params[key] = value
 
-                self.db.log_search(
-                    self.session_id,
-                    job_name,
-                    params,
-                    len(jobs_df),
-                    new_jobs,
-                    duration,
-                    site_counts,
-                    duplicate_counts,
-                    remote_count,
-                    avg_salary,
-                )
+                # Add proxies if available
+                if self.proxies:
+                    params["proxies"] = self.proxies
 
-                total_new_jobs += new_jobs
+                logger.info(f"Starting search for: {job_name}")
+                logger.info(f"Parameters: {params}")
 
-                logger.info(
-                    f"Search completed for {job_name}. Found {len(jobs_df)} jobs, {new_jobs} new."
-                )
-                
-            except Exception as e:
-                logger.error(f"Error searching for {job_name}: {str(e)}", exc_info=True)
-        
-        # Create backup after scraping to capture new data (only for production database)
-        if total_new_jobs > 0 and self.db.database_type == "production":
-            console.info(f"\nScraping completed with {total_new_jobs} new jobs added.")
-            console.info("Creating backup to capture new data...")
-            try:
-                backup_info = self.db.create_backup('auto', 'post_scraping')
-                console.info(f"✓ Post-scraping backup created: {backup_info['filename']} ({backup_info['size_mb']} MB)")
-                
-                # Manage retention after backup
-                retention_result = self.db.manage_backup_retention()
-                if retention_result['action'] == 'cleanup_performed':
-                    console.info(f"Backup retention: {retention_result['remaining_backups']} backups, {retention_result['total_size_gb']} GB")
-                    
-            except Exception as e:
-                logger.warning(f"Post-scraping backup failed: {e}")
-                console.info(f"⚠️  Post-scraping backup failed: {e}")
-        elif total_new_jobs == 0:
-            logger.info("No new jobs found, skipping post-scraping backup")
-        else:
-            logger.info("Working database scraping completed (no backup needed)")
-    
+                try:
+                    start_time = time.time()
+                    jobs_df = scrape_jobs(**params)
+
+                    (
+                        new_jobs,
+                        site_counts,
+                        duplicate_counts,
+                        remote_count,
+                        avg_salary,
+                    ) = self.db.insert_jobs(jobs_df, job_name)
+
+                    duration = time.time() - start_time
+
+                    self.db.log_search(
+                        self.session_id,
+                        job_name,
+                        params,
+                        len(jobs_df),
+                        new_jobs,
+                        duration,
+                        site_counts,
+                        duplicate_counts,
+                        remote_count,
+                        avg_salary,
+                    )
+
+                    total_new_jobs += new_jobs
+
+                    logger.info(
+                        f"Search completed for {job_name}. Found {len(jobs_df)} jobs, {new_jobs} new."
+                    )
+
+                except Exception as e:
+                    logger.error(
+                        f"Error searching for {job_name}: {str(e)}", exc_info=True
+                    )
+
+            # Create backup after scraping to capture new data (only for production database)
+            if total_new_jobs > 0 and self.db.database_type == "production":
+                console.info(f"\nScraping completed with {total_new_jobs} new jobs added.")
+                console.info("Creating backup to capture new data...")
+                try:
+                    backup_info = self.db.create_backup('auto', 'post_scraping')
+                    console.info(
+                        f"✓ Post-scraping backup created: {backup_info['filename']} ({backup_info['size_mb']} MB)"
+                    )
+
+                    # Manage retention after backup
+                    retention_result = self.db.manage_backup_retention()
+                    if retention_result['action'] == 'cleanup_performed':
+                        console.info(
+                            f"Backup retention: {retention_result['remaining_backups']} backups, {retention_result['total_size_gb']} GB"
+                        )
+
+                except Exception as e:
+                    logger.warning(f"Post-scraping backup failed: {e}")
+                    console.info(f"⚠️  Post-scraping backup failed: {e}")
+            elif total_new_jobs == 0:
+                logger.info("No new jobs found, skipping post-scraping backup")
+            else:
+                logger.info("Working database scraping completed (no backup needed)")
     
     
     def backup_and_reset_db(self) -> None:

--- a/jobscraps/session_manager.py
+++ b/jobscraps/session_manager.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from .database.core import JobDatabase
+
+logger = logging.getLogger(__name__)
+
+
+class SessionManager:
+    """Context manager to finalize scraping sessions."""
+
+    def __init__(self, db: JobDatabase, session_id: int) -> None:
+        self.db = db
+        self.session_id = session_id
+
+    def __enter__(self) -> int:
+        return self.session_id
+
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc: Optional[BaseException],
+        traceback: Optional[object],
+    ) -> None:
+        status = "error" if exc_type else "completed"
+        try:
+            self.db.end_session(self.session_id, status)
+        except Exception as err:  # pylint: disable=broad-except
+            logger.error("Failed to end session %s: %s", self.session_id, err)
+        return False
+


### PR DESCRIPTION
## Summary
- add end_time/status columns for search session tracking
- implement `JobDatabase.end_session`
- create `SessionManager` context manager
- finalize scraping sessions from `JobScraper.run`
- export `SessionManager`

## Testing
- `python -m py_compile jobscraps/session_manager.py jobscraps/database/core.py jobscraps/scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_685f5dbc42d4833284655944867612ca