### PR TITLE
Add config validation via JSON schema

### DIFF
--- a/jobscraps/__init__.py
+++ b/jobscraps/__init__.py
@@ -7,7 +7,7 @@ from .data_cleaner import DataCleaner
 from .scraping_orchestrator import ScrapingOrchestrator
 from .console_interface import console
 from .database import DatabaseConfig, JobDatabase, BackupMixin
-from .config import JobSearchConfig
+from .config import JobSearchConfig, ConfigurationError
 from .session_manager import SessionManager
 from .base_manager import BaseManager
 
@@ -22,6 +22,7 @@ __all__ = [
     "JobDatabase",
     "BackupMixin",
     "JobSearchConfig",
+    "ConfigurationError",
     "SessionManager",
     "BaseManager",
 ]

--- a/jobscraps/config.py
+++ b/jobscraps/config.py
@@ -6,7 +6,59 @@ import json
 import logging
 from typing import Dict, List
 
+from jsonschema import validate
+from jsonschema.exceptions import ValidationError
+
 SCRIPT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+class ConfigurationError(Exception):
+    """Raised when a configuration file is invalid."""
+
+
+CONFIG_SCHEMA: Dict = {
+    "type": "object",
+    "properties": {
+        "jobs": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "enabled": {"type": "boolean"},
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "site_name": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "search_term": {"type": "string"},
+                            "location": {"type": "string"},
+                            "results_wanted": {"type": "integer"},
+                            "hours_old": {"type": "integer"},
+                            "country_indeed": {"type": "string"},
+                        },
+                        "required": ["site_name", "search_term", "location"],
+                        "additionalProperties": True,
+                    },
+                },
+                "required": ["name", "parameters"],
+                "additionalProperties": True,
+            },
+        },
+        "global": {
+            "type": "object",
+            "properties": {
+                "description_format": {"type": "string"},
+                "enforce_annual_salary": {"type": "boolean"},
+                "verbose": {"type": "integer"},
+            },
+            "additionalProperties": True,
+        },
+    },
+    "required": ["jobs", "global"],
+}
 logger = logging.getLogger(__name__)
 
 
@@ -26,7 +78,10 @@ class JobSearchConfig:
         if config_dir and not os.path.exists(config_dir):
             os.makedirs(config_dir)
         if not os.path.exists(self.config_path):
-            logger.warning("Config file %s not found. Creating default configuration.", self.config_path)
+            logger.warning(
+                "Config file %s not found. Creating default configuration.",
+                self.config_path,
+            )
             default_config = {
                 "jobs": [
                     {
@@ -48,11 +103,17 @@ class JobSearchConfig:
                     "verbose": 1
                 }
             }
-            with open(self.config_path, 'w') as f:
+            with open(self.config_path, "w") as f:
                 json.dump(default_config, f, indent=4)
-            return default_config
-        with open(self.config_path, 'r') as f:
-            return json.load(f)
+            config_data = default_config
+        else:
+            with open(self.config_path, "r") as f:
+                config_data = json.load(f)
+        try:
+            validate(instance=config_data, schema=CONFIG_SCHEMA)
+        except ValidationError as exc:
+            raise ConfigurationError(f"Invalid configuration: {exc.message}") from exc
+        return config_data
 
     def get_job_configs(self) -> List[Dict]:
         """Return all enabled job configurations."""
@@ -62,4 +123,4 @@ class JobSearchConfig:
         """Return global parameters that apply to all searches."""
         return self.config.get("global", {})
 
-__all__ = ["JobSearchConfig"]
+__all__ = ["JobSearchConfig", "ConfigurationError"]


### PR DESCRIPTION
## Summary
- add a `ConfigurationError` exception and schema definition
- validate config data in `_load_config`
- export new error via package `__init__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fd452e350833289059d4b458cd327