### PR TITLE
Log errors during duplicate selection

### DIFF
--- a/jobscraps/duplicate_manager.py
+++ b/jobscraps/duplicate_manager.py
@@ -108,13 +108,22 @@ class DuplicateManager:
 
         # Step 8: Select by most recent date_posted
         if len(candidates) > 1:
-            jobs_with_dates = [job for job in candidates if job.get('date_posted') and job['date_posted'].strip()]
+            jobs_with_dates = [
+                job for job in candidates
+                if job.get('date_posted') and job['date_posted'].strip()
+            ]
             if jobs_with_dates:
                 try:
-                    jobs_with_dates.sort(key=lambda x: x['date_posted'], reverse=True)
+                    jobs_with_dates.sort(
+                        key=lambda x: x['date_posted'],
+                        reverse=True,
+                    )
                     return jobs_with_dates[0]
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.exception(
+                        "Error sorting jobs by date_posted: %s", e
+                    )
+                    return candidates[0]
         # Fallback
         return candidates[0]
 


### PR DESCRIPTION
## Summary
- handle exceptions when sorting by `date_posted`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fd79a68b88332b6dc011e3a5a40ff