### PR TITLE
Make duplicate preferences configurable

### DIFF
--- a/configs/search/job_search_config.json
+++ b/configs/search/job_search_config.json
@@ -18,6 +18,9 @@
     "global": {
         "description_format": "markdown",
         "enforce_annual_salary": true,
-        "verbose": 2
+        "verbose": 2,
+        "duplicate_preferences": {
+            "locations": ["Colorado"]
+        }
     }
 }

--- a/jobscraps/config.py
+++ b/jobscraps/config.py
@@ -100,7 +100,10 @@ class JobSearchConfig:
                 "global": {
                     "description_format": "markdown",
                     "enforce_annual_salary": True,
-                    "verbose": 1
+                    "verbose": 1,
+                    "duplicate_preferences": {
+                        "locations": ["Colorado"]
+                    }
                 }
             }
             with open(self.config_path, "w") as f:

--- a/jobscraps/duplicate_manager.py
+++ b/jobscraps/duplicate_manager.py
@@ -15,10 +15,11 @@ logger = logging.getLogger(__name__)
 class DuplicateManager:
     """Handle duplicate job detection and cleanup."""
 
-    def __init__(self, db: JobDatabase) -> None:
-        """Initialize the manager with a database connection."""
+    def __init__(self, db: JobDatabase, preferences: Dict | None = None) -> None:
+        """Initialize the manager with a database connection and preferences."""
         self.db = db
         self.site_preference = ['linkedin', 'indeed', 'google']
+        self.preferences: Dict = preferences or {}
 
     def identify_duplicates(self) -> Tuple[List[List[Dict]], List[str], List[str]]:
         """Identify duplicate jobs and determine which ones to keep/delete."""
@@ -45,18 +46,15 @@ class DuplicateManager:
         if len(candidates) == 1:
             return candidates[0]
 
-        # Step 2: Filter by Colorado location preference
-        colorado_jobs = [
-            job for job in candidates
-            if job.get('location') and (
-                ', CO' in job['location'] or
-                'Colorado' in job['location'] or
-                ', co' in job['location'].lower() or
-                'colorado' in job['location'].lower()
-            )
-        ]
-        if colorado_jobs and len(colorado_jobs) < len(candidates):
-            candidates = colorado_jobs
+        # Step 2: Filter by preferred locations from config
+        preferred_locations = [loc.lower() for loc in self.preferences.get('locations', [])]
+        if preferred_locations:
+            location_jobs = [
+                job for job in candidates
+                if job.get('location') and any(loc in job['location'].lower() for loc in preferred_locations)
+            ]
+            if location_jobs and len(location_jobs) < len(candidates):
+                candidates = location_jobs
         if len(candidates) == 1:
             return candidates[0]
 

--- a/jobscraps/scraper.py
+++ b/jobscraps/scraper.py
@@ -84,7 +84,8 @@ class JobScraper:
             db_config_path = os.path.join(SCRIPT_DIR, "configs", "db", "db_config.json")
         self.config = JobSearchConfig(config_path)
         self.db = get_connection(db_config_path, database_type)
-        self.duplicate_manager = DuplicateManager(self.db)
+        preferences = self.config.get_global_params().get("duplicate_preferences", {})
+        self.duplicate_manager = DuplicateManager(self.db, preferences)
 
         self.session_id = self.db.start_session()
         logger.info("Started search session %s", self.session_id)


### PR DESCRIPTION
## Summary
- add `duplicate_preferences` to default config
- pass preferences to `DuplicateManager`
- filter duplicate jobs by configured locations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fd8c608e88332a53d91fa5678e64b