### PR TITLE
Add migration script and instructions

### DIFF
--- a/data/schemas/README.md
+++ b/data/schemas/README.md
@@ -19,9 +19,21 @@ pg_dump -h HOST -p 5432 -U USER -d jobscraps \
 - **search_history**: Tracks scraping operations
 
 ## Schema Upgrades
-Migration scripts are stored in `data/schemas/migrations`. Apply them with psql:
+Migration scripts are stored in `data/schemas/migrations`.
+
+### Applying Individual Migrations
+Use `psql` to apply each migration in order:
 
 ```bash
 psql -h HOST -U USER -d jobscraps -f data/schemas/migrations/001_add_search_metrics.sql
 psql -h HOST -U USER -d jobscraps -f data/schemas/migrations/002_migrate_sessions.sql
 ```
+
+### Using the Helper Script
+To run all migrations sequentially, execute:
+
+```bash
+python dev/run_migrations.py
+```
+
+The script uses `configs/db/db_config.json` by default. Pass `--database-type working` to target the working database or `--config` to specify a custom config path.

--- a/dev/run_migrations.py
+++ b/dev/run_migrations.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Execute SQL migration files sequentially using psycopg2."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable
+
+import psycopg2
+
+from jobscraps.database.config import DatabaseConfig
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CONFIG = PROJECT_ROOT / "configs" / "db" / "db_config.json"
+MIGRATIONS_DIR = PROJECT_ROOT / "data" / "schemas" / "migrations"
+
+
+def iter_migration_files() -> Iterable[Path]:
+    """Yield migration SQL files in sorted order."""
+    return sorted(MIGRATIONS_DIR.glob("*.sql"))
+
+
+def apply_migration(conn: psycopg2.extensions.connection, path: Path) -> None:
+    """Execute a single SQL migration file."""
+    with conn.cursor() as cur, open(path, "r", encoding="utf-8") as sql_file:
+        cur.execute(sql_file.read())
+    conn.commit()
+
+
+def run_migrations(config_path: Path, database_type: str) -> None:
+    """Run all migrations against the selected database."""
+    db_conf = DatabaseConfig(str(config_path), database_type)
+    conn = psycopg2.connect(**db_conf.get_connection_params())
+
+    try:
+        for sql_file in iter_migration_files():
+            print(f"\u25ba Applying {sql_file.name}...", flush=True)
+            apply_migration(conn, sql_file)
+        print("\u2705 All migrations applied")
+    finally:
+        conn.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run JobScraps DB migrations")
+    parser.add_argument(
+        "--config",
+        "-c",
+        type=Path,
+        default=DEFAULT_CONFIG,
+        help="Path to db_config.json",
+    )
+    parser.add_argument(
+        "--database-type",
+        "-d",
+        choices=["production", "working"],
+        default="production",
+        help="Which database section to use from config",
+    )
+    args = parser.parse_args()
+
+    run_migrations(args.config, args.database_type)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add helper `dev/run_migrations.py` for applying SQL migrations
- document how to run migrations in `data/schemas/README.md`

## Testing
- `python -m py_compile dev/run_migrations.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686096a4f2e88332855916b9e17cd545