### PR TITLE
Fix create_tables for search_sessions

### DIFF
--- a/jobscraps/database/core.py
+++ b/jobscraps/database/core.py
@@ -114,12 +114,6 @@ class JobDatabase(BackupMixin):
             """
             )
             cursor.execute(
-                "ALTER TABLE search_sessions ADD COLUMN IF NOT EXISTS end_time TIMESTAMP"
-            )
-            cursor.execute(
-                "ALTER TABLE search_sessions ADD COLUMN IF NOT EXISTS status TEXT"
-            )
-            cursor.execute(
                 """
             CREATE TABLE IF NOT EXISTS search_history (
                 id SERIAL PRIMARY KEY,


### PR DESCRIPTION
## Summary
- remove redundant ALTER commands in `create_tables`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6860a57ed19c83328cdf7894884d8aea